### PR TITLE
Fixing broken autobuild

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,13 +1,24 @@
 #!/bin/bash
-set -exuo pipefail
+set -exo pipefail
+
+docker version
+
+echo "=== Environment info"
+echo SOURCE_BRANCH=$SOURCE_BRANCH
+echo SOURCE_COMMIT=$SOURCE_COMMIT
+echo COMMIT_MSG=$COMMIT_MSG
+echo DOCKERFILE_PATH=$DOCKERFILE_PATH
+echo DOCKER_REPO=$DOCKER_REPO
+echo DOCKER_TAG=$DOCKER_TAG
+echo IMAGE_NAME=$IMAGE_NAME
 
 echo "=== Build hook running"
 VCS_REF=$(git rev-parse --short HEAD)
+echo VCS_REF=$VCS_REF
 export VCS_REF
 export DOCKER_REPO=${DOCKER_REPO:-caddy/caddy}
 export DOCKER_TAG=${DOCKER_TAG:-latest}
 export IMAGE_NAME=${IMAGE_NAME:-${DOCKER_REPO}:${DOCKER_TAG}}
-
 
 if (git describe --abbrev=0 --exact-match &>/dev/null); then
   VERSION=$(git describe --abbrev=0 --exact-match)
@@ -26,3 +37,5 @@ for tag in "${tags[@]}"; do
         --tag "$DOCKER_REPO:$tag" \
         .
 done
+
+docker tag $DOCKER_REPO:scratch $IMAGE_NAME


### PR DESCRIPTION
The first auto build failed (GitHub `master` to the `:here-be-dragons` tag):

```
Pushing index.docker.io/caddy/caddy:here-be-dragons...
Push failed. Attempt 2 in 60 seconds.
Push failed. Attempt 3 in 60 seconds.
Push failed. Attempt 4 in 60 seconds.
Push failed. Attempt 5 in 60 seconds.
{u'message': u'tag does not exist: caddy/caddy:here-be-dragons'}
```

This happened because I forgot to tag something to `$IMAGE_NAME` 🤦‍♂

I've also added some extra output about the environment, partly for my curiosity, but also to help with troubleshooting down the line!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>