### PR TITLE
Adding data and config volumes

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -29,6 +29,9 @@ RUN git checkout $DIST_COMMIT
 RUN cp config/Caddyfile /Caddyfile
 RUN cp welcome/index.html /index.html
 
+RUN mkdir -p /data/caddy
+RUN mkdir -p /config/caddy
+
 {{ include "base" | strings.TrimSpace }}
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
@@ -36,6 +39,16 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs
 
 COPY --from=fetch-assets /Caddyfile /etc/caddy/Caddyfile
 COPY --from=fetch-assets /index.html /usr/share/caddy/index.html
+
+COPY --from=fetch-assets /data /data
+COPY --from=fetch-assets /config /config
+
+# See https://caddyserver.com/docs/conventions#file-locations for details
+ENV XDG_DATA_HOME=/data
+ENV XDG_CONFIG_HOME=/config
+
+VOLUME /data/caddy
+VOLUME /config/caddy
 
 ARG VERSION=v2.0.0-beta.15
 LABEL org.opencontainers.image.version=$VERSION

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -29,6 +29,9 @@ RUN git checkout $DIST_COMMIT
 RUN cp config/Caddyfile /Caddyfile
 RUN cp welcome/index.html /index.html
 
+RUN mkdir -p /data/caddy
+RUN mkdir -p /config/caddy
+
 FROM alpine:3.11.3
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
@@ -36,6 +39,15 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs
 
 COPY --from=fetch-assets /Caddyfile /etc/caddy/Caddyfile
 COPY --from=fetch-assets /index.html /usr/share/caddy/index.html
+
+COPY --from=fetch-assets /data /data
+COPY --from=fetch-assets /config /config
+
+ENV XDG_DATA_HOME=/data
+ENV XDG_CONFIG_HOME=/config
+
+VOLUME /data/caddy
+VOLUME /config/caddy
 
 ARG VERSION=v2.0.0-beta.15
 LABEL org.opencontainers.image.version=$VERSION

--- a/scratch/Dockerfile
+++ b/scratch/Dockerfile
@@ -29,6 +29,9 @@ RUN git checkout $DIST_COMMIT
 RUN cp config/Caddyfile /Caddyfile
 RUN cp welcome/index.html /index.html
 
+RUN mkdir -p /data/caddy
+RUN mkdir -p /config/caddy
+
 FROM scratch
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
@@ -36,6 +39,15 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs
 
 COPY --from=fetch-assets /Caddyfile /etc/caddy/Caddyfile
 COPY --from=fetch-assets /index.html /usr/share/caddy/index.html
+
+COPY --from=fetch-assets /data /data
+COPY --from=fetch-assets /config /config
+
+ENV XDG_DATA_HOME=/data
+ENV XDG_CONFIG_HOME=/config
+
+VOLUME /data/caddy
+VOLUME /config/caddy
 
 ARG VERSION=v2.0.0-beta.15
 LABEL org.opencontainers.image.version=$VERSION


### PR DESCRIPTION
This came up in #38. Right now persisting TLS certs and auto-saved config is undocumented and requires mounting volumes to `/root/.local/share` and `/root/.config`.

This sets the data and config paths to `/data/caddy` and `/config/caddy`, and configures them as `VOLUME`s to prevent data in these directories from persisting in the container. A user would then use them like so:

```command
$ docker run -p 80:80 -p 443:443 \
    -v caddy_data:/data -v caddy_config:/config \
    caddy/caddy
```

And this would persist data/config to volumes.

Another useful benefit is that the container can then be run in read-only mode (`docker run --read-only`) for some added security.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>