### PR TITLE
Stop using ARG instruction

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     git \
     ca-certificates
 
-ARG CADDY_SOURCE_VERSION=v2.0.0-beta.15
+ENV CADDY_SOURCE_VERSION={{ .config.caddy_version }}
 
 RUN git clone -b $CADDY_SOURCE_VERSION https://github.com/caddyserver/caddy.git --single-branch
 
@@ -20,7 +20,7 @@ FROM alpine:3.11.3 AS fetch-assets
 
 RUN apk add --no-cache git
 
-ARG DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
+ENV DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 WORKDIR /src/dist
 RUN git clone https://github.com/caddyserver/dist .
@@ -50,8 +50,7 @@ ENV XDG_CONFIG_HOME=/config
 VOLUME /data/caddy
 VOLUME /config/caddy
 
-ARG VERSION=v2.0.0-beta.15
-LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.version={{ .config.caddy_version }}
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ gen-dockerfiles: alpine/Dockerfile scratch/Dockerfile
 builder/Dockerfile: builder/Dockerfile.base Dockerfile.builder.tmpl stackbrew-config.yaml
 	@gomplate -d base=$< -c config=./stackbrew-config.yaml -f Dockerfile.builder.tmpl -o $@
 
-%/Dockerfile: %/Dockerfile.base Dockerfile.tmpl
-	@gomplate -d base=$< -f Dockerfile.tmpl -o $@
+%/Dockerfile: %/Dockerfile.base Dockerfile.tmpl stackbrew-config.yaml
+	@gomplate -d base=$< -c config=./stackbrew-config.yaml -f Dockerfile.tmpl -o $@
 
 library/caddy: stackbrew.tmpl stackbrew-config.yaml */Dockerfile Dockerfile.tmpl
 	@gomplate \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     git \
     ca-certificates
 
-ARG CADDY_SOURCE_VERSION=v2.0.0-beta.15
+ENV CADDY_SOURCE_VERSION=v2.0.0-beta.15
 
 RUN git clone -b $CADDY_SOURCE_VERSION https://github.com/caddyserver/caddy.git --single-branch
 
@@ -20,7 +20,7 @@ FROM alpine:3.11.3 AS fetch-assets
 
 RUN apk add --no-cache git
 
-ARG DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
+ENV DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 WORKDIR /src/dist
 RUN git clone https://github.com/caddyserver/dist .
@@ -43,14 +43,14 @@ COPY --from=fetch-assets /index.html /usr/share/caddy/index.html
 COPY --from=fetch-assets /data /data
 COPY --from=fetch-assets /config /config
 
+# See https://caddyserver.com/docs/conventions#file-locations for details
 ENV XDG_DATA_HOME=/data
 ENV XDG_CONFIG_HOME=/config
 
 VOLUME /data/caddy
 VOLUME /config/caddy
 
-ARG VERSION=v2.0.0-beta.15
-LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.version=v2.0.0-beta.15
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/scratch/Dockerfile
+++ b/scratch/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     git \
     ca-certificates
 
-ARG CADDY_SOURCE_VERSION=v2.0.0-beta.15
+ENV CADDY_SOURCE_VERSION=v2.0.0-beta.15
 
 RUN git clone -b $CADDY_SOURCE_VERSION https://github.com/caddyserver/caddy.git --single-branch
 
@@ -20,7 +20,7 @@ FROM alpine:3.11.3 AS fetch-assets
 
 RUN apk add --no-cache git
 
-ARG DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
+ENV DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 WORKDIR /src/dist
 RUN git clone https://github.com/caddyserver/dist .
@@ -43,14 +43,14 @@ COPY --from=fetch-assets /index.html /usr/share/caddy/index.html
 COPY --from=fetch-assets /data /data
 COPY --from=fetch-assets /config /config
 
+# See https://caddyserver.com/docs/conventions#file-locations for details
 ENV XDG_DATA_HOME=/data
 ENV XDG_CONFIG_HOME=/config
 
 VOLUME /data/caddy
 VOLUME /config/caddy
 
-ARG VERSION=v2.0.0-beta.15
-LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.version=v2.0.0-beta.15
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com


### PR DESCRIPTION
There isn't a way to provide build ars with bashbrew (nor would we want
to, to keep things repeatable).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>