### PR TITLE
Upgrade to v2.0.0-beta.19

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,11 +16,11 @@ RUN set -eux; \
 	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/$CADDY_DIST_COMMIT/welcome/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ENV CADDY_VERSION v2.0.0-beta.18
-ENV CADDY_CHECKSUM_SHA256 4f94e91f2ffabd00ddee4c9eac196f36754ed93da93cb24546ff4890918927d2
+ENV CADDY_VERSION v2.0.0-beta.19
+ENV CADDY_CHECKSUM_SHA256 8e44c8f801fd01f544738767af4ea76359dca17718d1aafcfa893ea45a837736
 # TODO: alter filename after v2 release (version will be taken out of name)
 RUN set -eux; \
-	wget -O /usr/bin/caddy "https://github.com/caddyserver/caddy/releases/download/$CADDY_VERSION/caddy2_beta18_linux_amd64"; \
+	wget -O /usr/bin/caddy "https://github.com/caddyserver/caddy/releases/download/$CADDY_VERSION/caddy2_beta19_linux_amd64"; \
 	echo "$CADDY_CHECKSUM_SHA256  /usr/bin/caddy" | sha256sum -c; \
 	chmod +x /usr/bin/caddy; \
 	caddy version
@@ -32,7 +32,7 @@ ENV XDG_DATA_HOME=/data
 VOLUME /config
 VOLUME /data
 
-LABEL org.opencontainers.image.version=v2.0.0-beta.18
+LABEL org.opencontainers.image.version=v2.0.0-beta.19
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     git \
     ca-certificates
 
-ENV CADDY_SOURCE_VERSION=v2.0.0-beta.18
+ENV CADDY_SOURCE_VERSION=v2.0.0-beta.19
 
 RUN git clone -b $CADDY_SOURCE_VERSION https://github.com/caddyserver/caddy.git --single-branch
 

--- a/stackbrew-config.yaml
+++ b/stackbrew-config.yaml
@@ -1,9 +1,9 @@
-caddy_version: v2.0.0-beta.18
-caddy_filename_prefix: caddy2_beta18
+caddy_version: v2.0.0-beta.19
+caddy_filename_prefix: caddy2_beta19
 # sha256 checksums for github-released binaries
 checksums:
-  amd64: 4f94e91f2ffabd00ddee4c9eac196f36754ed93da93cb24546ff4890918927d2
-  arm64v8: 35cda1dc206ffdad4a498b7d618ea4abcca653d0c01ecd9c156ed069442fb978
+  amd64: 8e44c8f801fd01f544738767af4ea76359dca17718d1aafcfa893ea45a837736
+  arm64v8: 2b938c63863d32c3e384d4a32d387b553623514f1ca6860574ca35bfe5c6e4c1
 # configuration for the stackbrew.tmpl template
 variants:
   - dir: alpine


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.0.0-beta.19

Signed-off-by: Dave Henderson <dhenderson@gmail.com>