### PR TITLE
Adding the mailcap package

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -1,6 +1,6 @@
 {{ include "base" | strings.TrimSpace }}
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates mailcap
 
 # https://github.com/caddyserver/dist/commits
 ENV CADDY_DIST_COMMIT 80870b227ded910971ecace4a0c136bf0ef46342

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates mailcap
 
 # https://github.com/caddyserver/dist/commits
 ENV CADDY_DIST_COMMIT 80870b227ded910971ecace4a0c136bf0ef46342


### PR DESCRIPTION
This'll help prevent issues like https://caddy.community/t/v2-how-to-handle-mime-information/7559 from surfacing.

By default, Go's `mime` package only knows about 11 MIME types. It will read additional types from `/etc/mime.types`, which is installed in the `mailcap` package.

This package is small, and contains 2 files:

```
/ # apk info -L mailcap
mailcap-2.1.48-r0 contains:
etc/mime.types
etc/mailcap
/ # ls -alh /etc/mime.types /etc/mailcap
-rw-r--r--    1 root     root         272 Dec 30  2017 /etc/mailcap
-rw-r--r--    1 root     root       58.9K Dec 30  2017 /etc/mime.types
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>