### PR TITLE
Windows 2016 TLS fix

### DIFF
--- a/Dockerfile.windows.tmpl
+++ b/Dockerfile.windows.tmpl
@@ -5,7 +5,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # https://github.com/caddyserver/dist/commits
 ENV CADDY_DIST_COMMIT 1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
-RUN mkdir /config; \
+# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    mkdir /config; \
     mkdir /data; \
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \

--- a/windows/1809/Dockerfile
+++ b/windows/1809/Dockerfile
@@ -5,7 +5,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # https://github.com/caddyserver/dist/commits
 ENV CADDY_DIST_COMMIT 1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
-RUN mkdir /config; \
+# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    mkdir /config; \
     mkdir /data; \
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \

--- a/windows/ltsc2016/Dockerfile
+++ b/windows/ltsc2016/Dockerfile
@@ -5,7 +5,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # https://github.com/caddyserver/dist/commits
 ENV CADDY_DIST_COMMIT 1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
-RUN mkdir /config; \
+# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    mkdir /config; \
     mkdir /data; \
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \


### PR DESCRIPTION
The [first `windowsservercore-ltsc2016` build](https://doi-janky.infosiftr.net/view/generators/job/multiarch/job/windows-amd64/job/caddy/1/console) failed:

```
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure 
channel.
At line:1 char:146
+ ... hare/caddy; Invoke-WebRequest -Uri https://github.com/caddyserver/dis ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:Htt 
   pWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShe 
   ll.Commands.InvokeWebRequestCommand
```

Fortunately, @tianon pointed me at a workaround: https://github.com/docker-library/golang/blob/e7fb0efd448658b759c2958744a8c59b53dcd6b3/Dockerfile-windows-windowsservercore.template#L16

Signed-off-by: Dave Henderson <dhenderson@gmail.com>