### PR TITLE
Add major version tag (caddy:2, etc)

### DIFF
--- a/stackbrew-config.yaml
+++ b/stackbrew-config.yaml
@@ -1,4 +1,5 @@
 caddy_version: '2.0.0'
+caddy_major: '2'
 # sha256 checksums for github-released binaries
 checksums:
   amd64: 3b00c705caa3162750dfea9cacd3f05ae1dda798e346293ba320ee63682a94e5e26c994fee75677324d841962757b098d2f696e4c5a0044131a0cd9b0e54b9fd
@@ -9,21 +10,21 @@ checksums:
 # configuration for the stackbrew.tmpl template
 variants:
   - dir: alpine
-    tags: [ "{{.conf.caddy_version}}-alpine", "alpine", ]
-    shared_tags: [ "{{.conf.caddy_version}}", "latest" ]
+    tags: [ "{{.conf.caddy_version}}-alpine", "{{.conf.caddy_major}}-alpine", "alpine", ]
+    shared_tags: [ "{{.conf.caddy_version}}", "{{.conf.caddy_major}}", "latest" ]
     architectures: [ amd64, arm64v8, arm32v6, arm32v7 ]
   - dir: builder
-    tags: [ "{{.conf.caddy_version}}-builder", "builder" ]
+    tags: [ "{{.conf.caddy_version}}-builder", "{{.conf.caddy_major}}-builder", "builder" ]
     architectures: [ amd64, arm64v8, arm32v6, arm32v7 ]
   - dir: windows/1809
     base_file: Dockerfile.windowsservercore-1809.base
-    tags: [ "{{.conf.caddy_version}}-windowsservercore-1809", "windowsservercore-1809" ]
-    shared_tags: [ "{{.conf.caddy_version}}-windowsservercore", "windowsservercore", "{{.conf.caddy_version}}", "latest" ]
+    tags: [ "{{.conf.caddy_version}}-windowsservercore-1809", "{{.conf.caddy_major}}-windowsservercore-1809", "windowsservercore-1809" ]
+    shared_tags: [ "{{.conf.caddy_version}}-windowsservercore", "{{.conf.caddy_major}}-windowsservercore", "windowsservercore", "{{.conf.caddy_version}}", "{{.conf.caddy_major}}", "latest" ]
     architectures: [ windows-amd64 ]
     constraints: [ windowsservercore-1809 ]
   - dir: windows/ltsc2016
     base_file: Dockerfile.windowsservercore-ltsc2016.base
-    tags: [ "{{.conf.caddy_version}}-windowsservercore-ltsc2016", "windowsservercore-ltsc2016" ]
-    shared_tags: [ "{{.conf.caddy_version}}-windowsservercore", "windowsservercore", "{{.conf.caddy_version}}", "latest" ]
+    tags: [ "{{.conf.caddy_version}}-windowsservercore-ltsc2016", "{{.conf.caddy_major}}-windowsservercore-ltsc2016", "windowsservercore-ltsc2016" ]
+    shared_tags: [ "{{.conf.caddy_version}}-windowsservercore", "{{.conf.caddy_major}}-windowsservercore", "windowsservercore", "{{.conf.caddy_version}}", "{{.conf.caddy_major}}", "latest" ]
     architectures: [ windows-amd64 ]
     constraints: [ windowsservercore-ltsc2016 ]


### PR DESCRIPTION
Adds additional tags. We talked about minor tags too (i.e. `caddy:2.0`), but for now those can wait.

```patch
diff --git a/library/caddy b/library/caddy
index c1d7d7b..6b0a1db 100644
--- a/library/caddy
+++ b/library/caddy
@@ -3,29 +3,29 @@
 # config context: https://github.com/caddyserver/caddy-docker/blob/d9baf11b7abb9343891bb9c28f8cc7137ae94b68/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.0.0-alpine, alpine
-SharedTags: 2.0.0, latest
+Tags: 2.0.0-alpine, 2-alpine, alpine
+SharedTags: 2.0.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: alpine
 GitCommit: d9baf11b7abb9343891bb9c28f8cc7137ae94b68
 Architectures: amd64, arm64v8, arm32v6, arm32v7
 
-Tags: 2.0.0-builder, builder
+Tags: 2.0.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: builder
 GitCommit: d9baf11b7abb9343891bb9c28f8cc7137ae94b68
 Architectures: amd64, arm64v8, arm32v6, arm32v7
 
-Tags: 2.0.0-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.0.0-windowsservercore, windowsservercore, 2.0.0, latest
+Tags: 2.0.0-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.0.0-windowsservercore, 2-windowsservercore, windowsservercore, 2.0.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: windows/1809
 GitCommit: d9baf11b7abb9343891bb9c28f8cc7137ae94b68
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.0.0-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.0.0-windowsservercore, windowsservercore, 2.0.0, latest
+Tags: 2.0.0-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.0.0-windowsservercore, 2-windowsservercore, windowsservercore, 2.0.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: windows/ltsc2016
 GitCommit: d9baf11b7abb9343891bb9c28f8cc7137ae94b68
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>