### PR TITLE
Set WORKDIR to /srv to avoid exposing /

### DIFF
--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -60,4 +60,6 @@ EXPOSE 80
 EXPOSE 443
 EXPOSE 2019
 
+WORKDIR /srv
+
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -60,4 +60,6 @@ EXPOSE 80
 EXPOSE 443
 EXPOSE 2019
 
+WORKDIR /srv
+
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -60,4 +60,6 @@ EXPOSE 80
 EXPOSE 443
 EXPOSE 2019
 
+WORKDIR /srv
+
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
When using a config like this:

```
:80
file_server browse
```

Caddy serves whatever's in the current working directory, which in the current image defaults to `/`

![image](https://user-images.githubusercontent.com/2037086/85805231-bd869280-b719-11ea-85f7-db961ec84f4a.png)

To prevent this from happening, we'll set it to `/srv`. Note that this doesn't force users to store their files in `/srv`, but just secures things a bit better!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>