### PR TITLE
builder: disable CGO for the entire environment

### DIFF
--- a/2.1/builder/caddy-builder.sh
+++ b/2.1/builder/caddy-builder.sh
@@ -35,6 +35,7 @@ replace github.com/caddyserver/caddy/v2 => /src/caddy
 EOF
 
 set -x
+export CGO_ENABLED=0
 go get "$@"
-CGO_ENABLED=0 go build -trimpath -tags netgo -ldflags '-extldflags "-static" -s -w' -o /usr/bin/caddy
+go build -trimpath -tags netgo -ldflags '-extldflags "-static" -s -w' -o /usr/bin/caddy
 /usr/bin/caddy version


### PR DESCRIPTION
Earlier script disables CGO at the build step, but not at the `go get` step. As `go` tries to `get` the dependencies, it will try to build them as well. Since `CGO_ENABLED` isn't set to `0` at that point, it will look for `gcc` to build the zstd package. Instead of having `CGO_ENABLED=0` in two lines, I opted for exporting it as `CGO_ENABLED=0` for the entire build environment.

Fixes #101 