### PR TITLE
chore: Improve ENV usage

### DIFF
--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.12
 RUN apk add --no-cache ca-certificates mailcap
 
 # https://github.com/caddyserver/dist/commits
-ARG CADDY_DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
+ENV CADDY_DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 RUN set -eux; \
 	mkdir -p \
@@ -16,7 +16,7 @@ RUN set -eux; \
 	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/${CADDY_DIST_COMMIT}/welcome/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ARG CADDY_VERSION=2.1.1
+ENV CADDY_VERSION=2.1.1
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.12
 RUN apk add --no-cache ca-certificates mailcap
 
 # https://github.com/caddyserver/dist/commits
-ENV CADDY_DIST_COMMIT 80870b227ded910971ecace4a0c136bf0ef46342
+ARG CADDY_DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 RUN set -eux; \
 	mkdir -p \
@@ -12,11 +12,11 @@ RUN set -eux; \
 		/etc/caddy \
 		/usr/share/caddy \
 	; \
-	wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/$CADDY_DIST_COMMIT/config/Caddyfile"; \
-	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/$CADDY_DIST_COMMIT/welcome/index.html"
+	wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/${CADDY_DIST_COMMIT}/config/Caddyfile"; \
+	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/${CADDY_DIST_COMMIT}/welcome/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ENV CADDY_VERSION v2.1.1
+ARG CADDY_VERSION=2.1.1
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
@@ -29,7 +29,7 @@ RUN set -eux; \
 		s390x)   binArch='s390x'; checksum='f4e16ad4f03f13cbe463efb8577d99f22a30161916cde10f5a0c838f7c57022b572b9a18d25fb20925aef4a5366537948ffdd4a191b3d5205ab9ab980406ca4b' ;; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;;\
 	esac; \
-	wget -O /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/download/v2.1.1/caddy_2.1.1_linux_${binArch}.tar.gz"; \
+	wget -O /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_${binArch}.tar.gz"; \
 	echo "$checksum  /tmp/caddy.tar.gz" | sha512sum -c; \
 	tar x -z -f /tmp/caddy.tar.gz -C /usr/bin caddy; \
 	rm -f /tmp/caddy.tar.gz; \
@@ -47,7 +47,7 @@ ENV XDG_DATA_HOME=/data
 VOLUME /config
 VOLUME /data
 
-LABEL org.opencontainers.image.version=v2.1.1
+LABEL org.opencontainers.image.version="v${CADDY_VERSION}"
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/2.1/windows/1809/Dockerfile
+++ b/2.1/windows/1809/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS caddy
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://github.com/caddyserver/dist/commits
-ENV CADDY_DIST_COMMIT 1ae255dd910fe0ad14aeec27eabe4f526bf423ab
+ARG CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
 # Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -12,18 +12,18 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/dist/raw/$env:CADDY_DIST_COMMIT/config/Caddyfile" \
+        -Uri "https://github.com/caddyserver/dist/raw/$($env:CADDY_DIST_COMMIT)/config/Caddyfile" \
         -OutFile "/etc/caddy/Caddyfile"; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/dist/raw/$env:CADDY_DIST_COMMIT/welcome/index.html" \
+        -Uri "https://github.com/caddyserver/dist/raw/$($env:CADDY_DIST_COMMIT)/welcome/index.html" \
         -OutFile "/usr/share/caddy/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ENV CADDY_VERSION v2.1.1
+ARG CADDY_VERSION=2.1.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/caddy/releases/download/v2.1.1/caddy_2.1.1_windows_amd64.zip" \
+        -Uri "https://github.com/caddyserver/caddy/releases/download/v$($env:CADDY_VERSION)/caddy_$($env:CADDY_VERSION)_windows_amd64.zip" \
         -OutFile "/caddy.zip"; \
     if (!(Get-FileHash -Path /caddy.zip -Algorithm SHA512).Hash.ToLower().Equals('435c881bf3d149da2339fdca28cf4bedcba79a3ed6bbd79365113e7e78bd110f544a13ab4976529cf73d4760c64991abed7b6f952ace4396ff5a78d98fcf3e19')) { exit 1; }; \
     Expand-Archive -Path "/caddy.zip" -DestinationPath "/" -Force; \
@@ -36,7 +36,7 @@ ENV XDG_DATA_HOME=c:/data
 VOLUME c:/config
 VOLUME c:/data
 
-LABEL org.opencontainers.image.version=v2.1.1
+LABEL org.opencontainers.image.version="v$($env:CADDY_VERSION)"
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/2.1/windows/1809/Dockerfile
+++ b/2.1/windows/1809/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS caddy
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://github.com/caddyserver/dist/commits
-ARG CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
+ENV CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
 # Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -19,7 +19,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
         -OutFile "/usr/share/caddy/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ARG CADDY_VERSION=2.1.1
+ENV CADDY_VERSION=2.1.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest \

--- a/2.1/windows/ltsc2016/Dockerfile
+++ b/2.1/windows/ltsc2016/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016 AS caddy
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://github.com/caddyserver/dist/commits
-ENV CADDY_DIST_COMMIT 1ae255dd910fe0ad14aeec27eabe4f526bf423ab
+ARG CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
 # Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -12,18 +12,18 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/dist/raw/$env:CADDY_DIST_COMMIT/config/Caddyfile" \
+        -Uri "https://github.com/caddyserver/dist/raw/$($env:CADDY_DIST_COMMIT)/config/Caddyfile" \
         -OutFile "/etc/caddy/Caddyfile"; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/dist/raw/$env:CADDY_DIST_COMMIT/welcome/index.html" \
+        -Uri "https://github.com/caddyserver/dist/raw/$($env:CADDY_DIST_COMMIT)/welcome/index.html" \
         -OutFile "/usr/share/caddy/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ENV CADDY_VERSION v2.1.1
+ARG CADDY_VERSION=2.1.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/caddy/releases/download/v2.1.1/caddy_2.1.1_windows_amd64.zip" \
+        -Uri "https://github.com/caddyserver/caddy/releases/download/v$($env:CADDY_VERSION)/caddy_$($env:CADDY_VERSION)_windows_amd64.zip" \
         -OutFile "/caddy.zip"; \
     if (!(Get-FileHash -Path /caddy.zip -Algorithm SHA512).Hash.ToLower().Equals('435c881bf3d149da2339fdca28cf4bedcba79a3ed6bbd79365113e7e78bd110f544a13ab4976529cf73d4760c64991abed7b6f952ace4396ff5a78d98fcf3e19')) { exit 1; }; \
     Expand-Archive -Path "/caddy.zip" -DestinationPath "/" -Force; \
@@ -36,7 +36,7 @@ ENV XDG_DATA_HOME=c:/data
 VOLUME c:/config
 VOLUME c:/data
 
-LABEL org.opencontainers.image.version=v2.1.1
+LABEL org.opencontainers.image.version="v$($env:CADDY_VERSION)"
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/2.1/windows/ltsc2016/Dockerfile
+++ b/2.1/windows/ltsc2016/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016 AS caddy
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://github.com/caddyserver/dist/commits
-ARG CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
+ENV CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
 # Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -19,7 +19,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
         -OutFile "/usr/share/caddy/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ARG CADDY_VERSION=2.1.1
+ENV CADDY_VERSION=2.1.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -3,7 +3,7 @@
 RUN apk add --no-cache ca-certificates mailcap
 
 # https://github.com/caddyserver/dist/commits
-ARG CADDY_DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
+ENV CADDY_DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 RUN set -eux; \
 	mkdir -p \
@@ -16,7 +16,7 @@ RUN set -eux; \
 	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/${CADDY_DIST_COMMIT}/welcome/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ARG CADDY_VERSION={{ .config.caddy_version }}
+ENV CADDY_VERSION={{ .config.caddy_version }}
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -3,7 +3,7 @@
 RUN apk add --no-cache ca-certificates mailcap
 
 # https://github.com/caddyserver/dist/commits
-ENV CADDY_DIST_COMMIT 80870b227ded910971ecace4a0c136bf0ef46342
+ARG CADDY_DIST_COMMIT=80870b227ded910971ecace4a0c136bf0ef46342
 
 RUN set -eux; \
 	mkdir -p \
@@ -12,11 +12,11 @@ RUN set -eux; \
 		/etc/caddy \
 		/usr/share/caddy \
 	; \
-	wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/$CADDY_DIST_COMMIT/config/Caddyfile"; \
-	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/$CADDY_DIST_COMMIT/welcome/index.html"
+	wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/${CADDY_DIST_COMMIT}/config/Caddyfile"; \
+	wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/${CADDY_DIST_COMMIT}/welcome/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ENV CADDY_VERSION v{{ .config.caddy_version }}
+ARG CADDY_VERSION={{ .config.caddy_version }}
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
@@ -29,7 +29,7 @@ RUN set -eux; \
 		s390x)   binArch='s390x'; checksum='{{ .config.checksums.s390x }}' ;; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;;\
 	esac; \
-	wget -O /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/download/v{{ .config.caddy_version }}/caddy_{{ .config.caddy_version }}_linux_${binArch}.tar.gz"; \
+	wget -O /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_${binArch}.tar.gz"; \
 	echo "$checksum  /tmp/caddy.tar.gz" | sha512sum -c; \
 	tar x -z -f /tmp/caddy.tar.gz -C /usr/bin caddy; \
 	rm -f /tmp/caddy.tar.gz; \
@@ -47,7 +47,7 @@ ENV XDG_DATA_HOME=/data
 VOLUME /config
 VOLUME /data
 
-LABEL org.opencontainers.image.version=v{{ .config.caddy_version }}
+LABEL org.opencontainers.image.version="v${CADDY_VERSION}"
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com

--- a/Dockerfile.windows.tmpl
+++ b/Dockerfile.windows.tmpl
@@ -3,7 +3,7 @@
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://github.com/caddyserver/dist/commits
-ARG CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
+ENV CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
 # Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -19,7 +19,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
         -OutFile "/usr/share/caddy/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ARG CADDY_VERSION={{ .config.caddy_version }}
+ENV CADDY_VERSION={{ .config.caddy_version }}
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest \

--- a/Dockerfile.windows.tmpl
+++ b/Dockerfile.windows.tmpl
@@ -3,7 +3,7 @@
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # https://github.com/caddyserver/dist/commits
-ENV CADDY_DIST_COMMIT 1ae255dd910fe0ad14aeec27eabe4f526bf423ab
+ARG CADDY_DIST_COMMIT=1ae255dd910fe0ad14aeec27eabe4f526bf423ab
 
 # Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -12,18 +12,18 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/dist/raw/$env:CADDY_DIST_COMMIT/config/Caddyfile" \
+        -Uri "https://github.com/caddyserver/dist/raw/$($env:CADDY_DIST_COMMIT)/config/Caddyfile" \
         -OutFile "/etc/caddy/Caddyfile"; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/dist/raw/$env:CADDY_DIST_COMMIT/welcome/index.html" \
+        -Uri "https://github.com/caddyserver/dist/raw/$($env:CADDY_DIST_COMMIT)/welcome/index.html" \
         -OutFile "/usr/share/caddy/index.html"
 
 # https://github.com/caddyserver/caddy/releases
-ENV CADDY_VERSION v{{ .config.caddy_version }}
+ARG CADDY_VERSION={{ .config.caddy_version }}
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest \
-        -Uri "https://github.com/caddyserver/caddy/releases/download/v{{ .config.caddy_version }}/caddy_{{ .config.caddy_version }}_windows_amd64.zip" \
+        -Uri "https://github.com/caddyserver/caddy/releases/download/v$($env:CADDY_VERSION)/caddy_$($env:CADDY_VERSION)_windows_amd64.zip" \
         -OutFile "/caddy.zip"; \
     if (!(Get-FileHash -Path /caddy.zip -Algorithm SHA512).Hash.ToLower().Equals('{{ .config.checksums.windows_amd64 }}')) { exit 1; }; \
     Expand-Archive -Path "/caddy.zip" -DestinationPath "/" -Force; \
@@ -36,7 +36,7 @@ ENV XDG_DATA_HOME=c:/data
 VOLUME c:/config
 VOLUME c:/data
 
-LABEL org.opencontainers.image.version=v{{ .config.caddy_version }}
+LABEL org.opencontainers.image.version="v$($env:CADDY_VERSION)"
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 LABEL org.opencontainers.image.url=https://caddyserver.com


### PR DESCRIPTION
This is [my earlier PR](https://github.com/caddyserver/caddy-docker/pull/110) with the ARG instructions reverted back to ENV.

- `CADDY_VERSION` ENV is now used in Dockerfiles where the template variables were skipping the ENV and hardcoding strings (which is fine, but the ENV served no purpose).
- ENV usage no longer has ambiguous length in strings (previously relied on `/` to implicitly end the variable name).