### PR TITLE
Deprecate the caddy-builder.sh script

### DIFF
--- a/2.1/builder/Dockerfile.sample
+++ b/2.1/builder/Dockerfile.sample
@@ -1,9 +1,0 @@
-FROM b AS builder
-
-RUN caddy-builder \
-    github.com/caddyserver/nginx-adapter \
-    github.com/hairyhenderson/caddy-teapot-module@v0.0.2
-
-FROM caddy/caddy
-
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/2.1/builder/caddy-builder.sh
+++ b/2.1/builder/caddy-builder.sh
@@ -6,6 +6,12 @@ for p; do
 	args="$args --with $p"
 done
 
+echo "Warning: the caddy-builder script is deprecated and will be removed in the future.
+Instead, you should use the xcaddy command:
+
+    xcaddy build $args
+" >&2
+
 # version is inferred from $CADDY_VERSION (set in the Dockerfile)
 # output will be placed in the working dir (/usr/bin as set in the Dockerfile)
 xcaddy build $args

--- a/2.1/windows-builder/1809/Dockerfile
+++ b/2.1/windows-builder/1809/Dockerfile
@@ -17,7 +17,4 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive -Path "/xcaddy.zip" -DestinationPath "/" -Force; \
     Remove-Item "/xcaddy.zip" -Force
 
-COPY caddy-builder.ps1 /caddy-builder.ps1
-RUN New-Alias -Name caddy-builder -Value /caddy-builder.ps1
-
 WORKDIR /

--- a/2.1/windows-builder/1809/caddy-builder.ps1
+++ b/2.1/windows-builder/1809/caddy-builder.ps1
@@ -1,8 +1,0 @@
-$withArgs = ""
-foreach ($arg in $Args) {
-	$withArgs += " --with $arg"
-}
-
-# version is inferred from $CADDY_VERSION (set in the Dockerfile)
-# output will be placed in the working dir (/ as set in the Dockerfile)
-xcaddy build $withArgs

--- a/2.1/windows-builder/ltsc2016/Dockerfile
+++ b/2.1/windows-builder/ltsc2016/Dockerfile
@@ -17,7 +17,4 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive -Path "/xcaddy.zip" -DestinationPath "/" -Force; \
     Remove-Item "/xcaddy.zip" -Force
 
-COPY caddy-builder.ps1 /caddy-builder.ps1
-RUN New-Alias -Name caddy-builder -Value /caddy-builder.ps1
-
 WORKDIR /

--- a/2.1/windows-builder/ltsc2016/caddy-builder.ps1
+++ b/2.1/windows-builder/ltsc2016/caddy-builder.ps1
@@ -1,8 +1,0 @@
-$withArgs = ""
-foreach ($arg in $Args) {
-	$withArgs += " --with $arg"
-}
-
-# version is inferred from $CADDY_VERSION (set in the Dockerfile)
-# output will be placed in the working dir (/ as set in the Dockerfile)
-xcaddy build $withArgs

--- a/2.2/builder/Dockerfile.sample
+++ b/2.2/builder/Dockerfile.sample
@@ -1,9 +1,0 @@
-FROM b AS builder
-
-RUN caddy-builder \
-    github.com/caddyserver/nginx-adapter \
-    github.com/hairyhenderson/caddy-teapot-module@v0.0.3-0
-
-FROM caddy/caddy
-
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/2.2/builder/caddy-builder.sh
+++ b/2.2/builder/caddy-builder.sh
@@ -6,6 +6,12 @@ for p; do
 	args="$args --with $p"
 done
 
+echo "Warning: the caddy-builder script is deprecated and will be removed in the future.
+Instead, you should use the xcaddy command:
+
+    xcaddy build $args
+" >&2
+
 # version is inferred from $CADDY_VERSION (set in the Dockerfile)
 # output will be placed in the working dir (/usr/bin as set in the Dockerfile)
 xcaddy build $args

--- a/2.2/windows-builder/1809/Dockerfile
+++ b/2.2/windows-builder/1809/Dockerfile
@@ -17,7 +17,4 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive -Path "/xcaddy.zip" -DestinationPath "/" -Force; \
     Remove-Item "/xcaddy.zip" -Force
 
-COPY caddy-builder.ps1 /caddy-builder.ps1
-RUN New-Alias -Name caddy-builder -Value /caddy-builder.ps1
-
 WORKDIR /

--- a/2.2/windows-builder/1809/caddy-builder.ps1
+++ b/2.2/windows-builder/1809/caddy-builder.ps1
@@ -1,8 +1,0 @@
-$withArgs = ""
-foreach ($arg in $Args) {
-	$withArgs += " --with $arg"
-}
-
-# version is inferred from $CADDY_VERSION (set in the Dockerfile)
-# output will be placed in the working dir (/ as set in the Dockerfile)
-xcaddy build $withArgs

--- a/2.2/windows-builder/ltsc2016/Dockerfile
+++ b/2.2/windows-builder/ltsc2016/Dockerfile
@@ -17,7 +17,4 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive -Path "/xcaddy.zip" -DestinationPath "/" -Force; \
     Remove-Item "/xcaddy.zip" -Force
 
-COPY caddy-builder.ps1 /caddy-builder.ps1
-RUN New-Alias -Name caddy-builder -Value /caddy-builder.ps1
-
 WORKDIR /

--- a/2.2/windows-builder/ltsc2016/caddy-builder.ps1
+++ b/2.2/windows-builder/ltsc2016/caddy-builder.ps1
@@ -1,8 +1,0 @@
-$withArgs = ""
-foreach ($arg in $Args) {
-	$withArgs += " --with $arg"
-}
-
-# version is inferred from $CADDY_VERSION (set in the Dockerfile)
-# output will be placed in the working dir (/ as set in the Dockerfile)
-xcaddy build $withArgs

--- a/Dockerfile.windows-builder.tmpl
+++ b/Dockerfile.windows-builder.tmpl
@@ -17,7 +17,4 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive -Path "/xcaddy.zip" -DestinationPath "/" -Force; \
     Remove-Item "/xcaddy.zip" -Force
 
-COPY caddy-builder.ps1 /caddy-builder.ps1
-RUN New-Alias -Name caddy-builder -Value /caddy-builder.ps1
-
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ gen-dockerfiles: render-dockerfiles.tmpl Dockerfile.tmpl Dockerfile.builder.tmpl
 		-t windows-dockerfile=Dockerfile.windows.tmpl \
 		-t windows-builder-dockerfile=Dockerfile.windows-builder.tmpl \
 		-t caddy-builder=caddy-builder.sh.tmpl \
-		-t caddy-windows-builder=caddy-builder.ps1.tmpl \
 		-c config=./stackbrew-config.yaml \
 		-f $<
 

--- a/caddy-builder.ps1.tmpl
+++ b/caddy-builder.ps1.tmpl
@@ -1,8 +1,0 @@
-$withArgs = ""
-foreach ($arg in $Args) {
-	$withArgs += " --with $arg"
-}
-
-# version is inferred from $CADDY_VERSION (set in the Dockerfile)
-# output will be placed in the working dir (/ as set in the Dockerfile)
-xcaddy build $withArgs

--- a/caddy-builder.sh.tmpl
+++ b/caddy-builder.sh.tmpl
@@ -6,6 +6,12 @@ for p; do
 	args="$args --with $p"
 done
 
+echo "Warning: the caddy-builder script is deprecated and will be removed in the future.
+Instead, you should use the xcaddy command:
+
+    xcaddy build $args
+" >&2
+
 # version is inferred from $CADDY_VERSION (set in the Dockerfile)
 # output will be placed in the working dir (/usr/bin as set in the Dockerfile)
 xcaddy build $args

--- a/render-dockerfiles.tmpl
+++ b/render-dockerfiles.tmpl
@@ -26,12 +26,5 @@ Rendering {{ $outPath }} with template {{ $template }}...{{ "\n" -}}
 Rendering {{ $outPath }} with template {{ $template }}...{{ "\n" -}}
 			{{- tmpl.Exec $template $ctx | file.Write $outPath -}}
 		{{ end -}}
-		{{- if strings.HasPrefix "windows-builder" $variant.dir -}}
-			{{- $template = "caddy-windows-builder" }}
-			{{- $ctx := dict "config" $version }}
-			{{- $outPath := filepath.Join $dir "caddy-builder.ps1" -}}
-Rendering {{ $outPath }} with template {{ $template }}...{{ "\n" -}}
-			{{- tmpl.Exec $template $ctx | file.Write $outPath -}}
-		{{ end -}}
 	{{- end }}
 {{- end -}}


### PR DESCRIPTION
Meant to do this when introducing xcaddy, but forgot 🤦‍♂️

This:
- deletes the Windows caddy-builder script (best not to create a script that's only going to be deprecated)
- adds a warning message so that users will know to stop using caddy-builder

Signed-off-by: Dave Henderson <dhenderson@gmail.com>