### PR TITLE
Make CADDY_VERSION an ARG instead of ENV

### DIFF
--- a/Dockerfile.builder.tmpl
+++ b/Dockerfile.builder.tmpl
@@ -6,7 +6,8 @@ RUN apk add --no-cache \
 
 ENV XCADDY_VERSION v{{ .xcaddy_config.version }}
 # Configures xcaddy to build with this version of Caddy
-ENV CADDY_VERSION v{{ .config.caddy_version }}
+ARG CADDY_VERSION=v{{ .config.caddy_version }}
+ENV CADDY_VERSION $CADDY_VERSION
 # Configures xcaddy to not clean up post-build (unnecessary in a container)
 ENV XCADDY_SKIP_CLEANUP 1
 

--- a/Dockerfile.windows-builder.tmpl
+++ b/Dockerfile.windows-builder.tmpl
@@ -4,7 +4,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ENV XCADDY_VERSION v{{ .xcaddy_config.version }}
 # Configures xcaddy to build with this version of Caddy
-ENV CADDY_VERSION v{{ .config.caddy_version }}
+ARG CADDY_VERSION=v{{ .config.caddy_version }}
+ENV CADDY_VERSION $CADDY_VERSION
 # Configures xcaddy to not clean up post-build (unnecessary in a container)
 ENV XCADDY_SKIP_CLEANUP 1
 


### PR DESCRIPTION
This change allows overriding it's value when building as ARGs can be set with --build-arg but ENVs can't.

I think it's safe to change `CADDY_VERSION` like so because xcaddy can build multiple caddy versions.
I didn't change `XCADDY_VERSION` as that would break the checksum verification.