### PR TITLE
update Windows Server ltsc2016 to ltsc2022

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     timezone: UTC
   open-pull-requests-limit: 10
 - package-ecosystem: docker
-  directory: "/2.4/windows/ltsc2016"
+  directory: "/2.4/windows/ltsc2022"
   schedule:
     interval: daily
     time: "02:00"
@@ -36,7 +36,7 @@ updates:
     timezone: UTC
   open-pull-requests-limit: 10
 - package-ecosystem: docker
-  directory: "/2.4/windows-builder/ltsc2016"
+  directory: "/2.4/windows-builder/ltsc2022"
   schedule:
     interval: daily
     time: "02:00"

--- a/2.4/windows-builder/ltsc2016/Dockerfile.base
+++ b/2.4/windows-builder/ltsc2016/Dockerfile.base
@@ -1,1 +1,0 @@
-FROM golang:1.17-windowsservercore-ltsc2016

--- a/2.4/windows-builder/ltsc2022/Dockerfile
+++ b/2.4/windows-builder/ltsc2022/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-windowsservercore-ltsc2016
+FROM golang:1.17-windowsservercore-ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.4/windows-builder/ltsc2022/Dockerfile.base
+++ b/2.4/windows-builder/ltsc2022/Dockerfile.base
@@ -1,0 +1,1 @@
+FROM golang:1.17-windowsservercore-ltsc2022

--- a/2.4/windows/ltsc2016/Dockerfile.base
+++ b/2.4/windows/ltsc2016/Dockerfile.base
@@ -1,1 +1,0 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2016

--- a/2.4/windows/ltsc2022/Dockerfile
+++ b/2.4/windows/ltsc2022/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.4/windows/ltsc2022/Dockerfile.base
+++ b/2.4/windows/ltsc2022/Dockerfile.base
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2022

--- a/stackbrew-config.yaml
+++ b/stackbrew-config.yaml
@@ -37,19 +37,19 @@ variants:
     shared_tags: [ "windowsservercore", "latest" ]
     architectures: [ windows-amd64 ]
     constraints: [ windowsservercore-1809 ]
-  - dir: windows/ltsc2016
-    base_file: Dockerfile.windowsservercore-ltsc2016.base
-    tags: [ "windowsservercore-ltsc2016" ]
+  - dir: windows/ltsc2022
+    base_file: Dockerfile.windowsservercore-ltsc2022.base
+    tags: [ "windowsservercore-ltsc2022" ]
     shared_tags: [ "windowsservercore", "latest" ]
     architectures: [ windows-amd64 ]
-    constraints: [ windowsservercore-ltsc2016 ]
+    constraints: [ windowsservercore-ltsc2022 ]
   - dir: windows-builder/1809
     tags: [ "builder-windowsservercore-1809" ]
     shared_tags: [ "builder" ]
     architectures: [ windows-amd64 ]
     constraints: [ windowsservercore-1809 ]
-  - dir: windows-builder/ltsc2016
-    tags: [ "builder-windowsservercore-ltsc2016" ]
+  - dir: windows-builder/ltsc2022
+    tags: [ "builder-windowsservercore-ltsc2022" ]
     shared_tags: [ "builder" ]
     architectures: [ windows-amd64 ]
-    constraints: [ windowsservercore-ltsc2016 ]
+    constraints: [ windowsservercore-ltsc2022 ]


### PR DESCRIPTION
see https://github.com/docker-library/official-images/pull/11661 and https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle