### PR TITLE
Remove explicit VOLUME instructions

### DIFF
--- a/2.5/alpine/Dockerfile
+++ b/2.5/alpine/Dockerfile
@@ -41,9 +41,6 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 ENV XDG_CONFIG_HOME /config
 ENV XDG_DATA_HOME /data
 
-VOLUME /config
-VOLUME /data
-
 LABEL org.opencontainers.image.version=v2.5.0-rc.1
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"

--- a/2.5/windows/1809/Dockerfile
+++ b/2.5/windows/1809/Dockerfile
@@ -30,9 +30,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 ENV XDG_CONFIG_HOME c:/config
 ENV XDG_DATA_HOME c:/data
 
-VOLUME c:/config
-VOLUME c:/data
-
 LABEL org.opencontainers.image.version=v2.5.0-rc.1
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"

--- a/2.5/windows/ltsc2022/Dockerfile
+++ b/2.5/windows/ltsc2022/Dockerfile
@@ -30,9 +30,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 ENV XDG_CONFIG_HOME c:/config
 ENV XDG_DATA_HOME c:/data
 
-VOLUME c:/config
-VOLUME c:/data
-
 LABEL org.opencontainers.image.version=v2.5.0-rc.1
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -41,9 +41,6 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 ENV XDG_CONFIG_HOME /config
 ENV XDG_DATA_HOME /data
 
-VOLUME /config
-VOLUME /data
-
 LABEL org.opencontainers.image.version=v{{ .config.caddy_version }}
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"

--- a/Dockerfile.windows.tmpl
+++ b/Dockerfile.windows.tmpl
@@ -30,9 +30,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 ENV XDG_CONFIG_HOME c:/config
 ENV XDG_DATA_HOME c:/data
 
-VOLUME c:/config
-VOLUME c:/data
-
 LABEL org.opencontainers.image.version=v{{ .config.caddy_version }}
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"


### PR DESCRIPTION
#### :book: Summary

 Removes the controversial VOLUME instructions in the Dockerfiles.

#### :bookmark_tabs: Test Plan

> :bulb: Select your test plan for the code changes.

- [ ] Tested via Github Actions
- [ ] Custom test
- [ ] No test plan

##### Details / Justification

<!-- Add your test details or justification for missing tests here. -->

#### :books: Additional Notes

As already mentioned, there should be an additional warning message about the changes and how to deal with the dopped implicit volume definitions

- 📌 fixes #118