### PR TITLE
Allow to pass Caddyfile config via environment variable

### DIFF
--- a/2.5/alpine/Dockerfile
+++ b/2.5/alpine/Dockerfile
@@ -56,4 +56,8 @@ EXPOSE 2019
 
 WORKDIR /srv
 
+COPY entrypoint.sh /bin/entrypoint.sh
+
+ENTRYPOINT [ "entrypoint.sh" ]
+
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/2.5/alpine/entrypoint.sh
+++ b/2.5/alpine/entrypoint.sh
@@ -3,7 +3,7 @@
 # Check if Caddyfile config is passed via $CADDYFILE
 if [[ "$CADDYFILE" ]]; then
     echo 'Storing $CADDYFILE variable to ./Caddyfile'
-    echo -e $CADDYFILE > Caddyfile
+    printf "$CADDYFILE" > Caddyfile # echo doesn't preserve newlines
 fi
 
 # Running passed command

--- a/2.5/alpine/entrypoint.sh
+++ b/2.5/alpine/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Check if Caddyfile config is passed via $CADDYFILE
+if [[ "$CADDYFILE" ]]; then
+    echo 'Storing $CADDYFILE variable to /etc/caddy/Caddyfile'
+    echo -e $CADDYFILE > /etc/caddy/Caddyfile
+fi
+
+# Running passed command
+if [[ "$1" ]]; then
+    eval "$@"
+fi

--- a/2.5/alpine/entrypoint.sh
+++ b/2.5/alpine/entrypoint.sh
@@ -8,5 +8,5 @@ fi
 
 # Running passed command
 if [[ "$1" ]]; then
-    eval "$@"
+    exec $@
 fi

--- a/2.5/alpine/entrypoint.sh
+++ b/2.5/alpine/entrypoint.sh
@@ -2,8 +2,8 @@
 
 # Check if Caddyfile config is passed via $CADDYFILE
 if [[ "$CADDYFILE" ]]; then
-    echo 'Storing $CADDYFILE variable to /etc/caddy/Caddyfile'
-    echo -e $CADDYFILE > /etc/caddy/Caddyfile
+    echo 'Storing $CADDYFILE variable to ./Caddyfile'
+    echo -e $CADDYFILE > Caddyfile
 fi
 
 # Running passed command

--- a/2.5/alpine/entrypoint.sh
+++ b/2.5/alpine/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Check if Caddyfile config is passed via $CADDYFILE
 if [[ "$CADDYFILE" ]]; then
@@ -8,5 +9,5 @@ fi
 
 # Running passed command
 if [[ "$1" ]]; then
-    exec $@
+    exec "$@"
 fi


### PR DESCRIPTION
Sometimes it can be convenient to pass the config via an environment variable in order to avoid mounting a config file into the docker container.

For example, I wasn't able to figure out an elegant way to pass a Caddyfile from an [Azure Container Group YAML](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-reference-yaml).
This way I was able to avoid creating an Azure File Share that can be mounted.

# Implementation

An `entrypoint.sh` script was added, which checks if the variable `CADDYFILE` is set. If it is, the content is written to `./Caddyfile`.
Afterward, the command passed to the container is executed. 

# Usage example

This PR can be tested like this with `docker compose`

```YAML
version: "3.9"
services:
  caddy:
    image: haraldreingruberdedalus/caddy:latest
    command: 'cat Caddyfile'
    environment:
      CADDYFILE: |
        # Reverse proxy from localhost:80 to localhost:8080
        localhost:80 {
          reverse_proxy localhost:8080
        }


```

Maybe there are more elegant ideas to achieve this. Looking forward to your input.