### PR TITLE
Windows 1809 builder should use at least Go 1.18

### DIFF
--- a/2.5/windows-builder/1809/Dockerfile
+++ b/2.5/windows-builder/1809/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-windowsservercore-1809
+FROM golang:1.18-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.5/windows-builder/1809/Dockerfile.base
+++ b/2.5/windows-builder/1809/Dockerfile.base
@@ -1,1 +1,1 @@
-FROM golang:1.17-windowsservercore-1809
+FROM golang:1.18-windowsservercore-1809


### PR DESCRIPTION
Back in https://github.com/caddyserver/caddy-docker/pull/226, the LTSC2022 image was updated, but for some reason the 1809 image got lost.

This is now causing [CI for the 2.6.0-beta.3 image](https://github.com/docker-library/official-images/pull/13100) to fail, because the `golang:1.17-windowsservercore-1809` upstream image is "naughty" (i.e. unsupported and disallowed).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>