### PR TITLE
windows: Remove redundant TLS 1.2 enabling

### DIFF
--- a/2.6/windows-builder/1809/Dockerfile
+++ b/2.6/windows-builder/1809/Dockerfile
@@ -8,9 +8,7 @@ ENV CADDY_VERSION v2.6.4
 # Configures xcaddy to not clean up post-build (unnecessary in a container)
 ENV XCADDY_SKIP_CLEANUP 1
 
-# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest \
+RUN Invoke-WebRequest \
         -Uri "https://github.com/caddyserver/xcaddy/releases/download/v0.3.2/xcaddy_0.3.2_windows_amd64.zip" \
         -OutFile "/xcaddy.zip"; \
     if (!(Get-FileHash -Path /xcaddy.zip -Algorithm SHA512).Hash.ToLower().Equals('8de1cb65e555e8d7f1124d384904cd53a37d1914106af6ec1cef92f1975bd66b5a1f0e066c2c6b68c85d67de54d52f170f539dff117ce97f4166d8e984a728ba')) { exit 1; }; \

--- a/2.6/windows-builder/ltsc2022/Dockerfile
+++ b/2.6/windows-builder/ltsc2022/Dockerfile
@@ -8,9 +8,7 @@ ENV CADDY_VERSION v2.6.4
 # Configures xcaddy to not clean up post-build (unnecessary in a container)
 ENV XCADDY_SKIP_CLEANUP 1
 
-# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest \
+RUN Invoke-WebRequest \
         -Uri "https://github.com/caddyserver/xcaddy/releases/download/v0.3.2/xcaddy_0.3.2_windows_amd64.zip" \
         -OutFile "/xcaddy.zip"; \
     if (!(Get-FileHash -Path /xcaddy.zip -Algorithm SHA512).Hash.ToLower().Equals('8de1cb65e555e8d7f1124d384904cd53a37d1914106af6ec1cef92f1975bd66b5a1f0e066c2c6b68c85d67de54d52f170f539dff117ce97f4166d8e984a728ba')) { exit 1; }; \

--- a/2.6/windows/1809/Dockerfile
+++ b/2.6/windows/1809/Dockerfile
@@ -2,9 +2,7 @@ FROM mcr.microsoft.com/windows/servercore:1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    mkdir /config; \
+RUN mkdir /config; \
     mkdir /data; \
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \
@@ -18,8 +16,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 # https://github.com/caddyserver/caddy/releases
 ENV CADDY_VERSION v2.6.4
 
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest \
+RUN Invoke-WebRequest \
         -Uri "https://github.com/caddyserver/caddy/releases/download/v2.6.4/caddy_2.6.4_windows_amd64.zip" \
         -OutFile "/caddy.zip"; \
     if (!(Get-FileHash -Path /caddy.zip -Algorithm SHA512).Hash.ToLower().Equals('e2a9a708786cc498cf4b12c0aaf2c9731cc89ccef71a7da4c2be60e18d730675890c2d6bbddd3d8347e5f89f348d5e74fbfbf339ed1ec280f5caf69c3849a243')) { exit 1; }; \

--- a/2.6/windows/ltsc2022/Dockerfile
+++ b/2.6/windows/ltsc2022/Dockerfile
@@ -2,9 +2,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# Apparently Windows Server 2016 disables TLS 1.2 by default - this enables it so we can talk to GitHub
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    mkdir /config; \
+RUN mkdir /config; \
     mkdir /data; \
     mkdir /etc/caddy; \
     mkdir /usr/share/caddy; \
@@ -18,8 +16,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 # https://github.com/caddyserver/caddy/releases
 ENV CADDY_VERSION v2.6.4
 
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest \
+RUN Invoke-WebRequest \
         -Uri "https://github.com/caddyserver/caddy/releases/download/v2.6.4/caddy_2.6.4_windows_amd64.zip" \
         -OutFile "/caddy.zip"; \
     if (!(Get-FileHash -Path /caddy.zip -Algorithm SHA512).Hash.ToLower().Equals('e2a9a708786cc498cf4b12c0aaf2c9731cc89ccef71a7da4c2be60e18d730675890c2d6bbddd3d8347e5f89f348d5e74fbfbf339ed1ec280f5caf69c3849a243')) { exit 1; }; \


### PR DESCRIPTION
TLS 1.2 is enforced by default, removed enable tls12 part

Should close issue #285 