### PR TITLE
fix: use Go 1.20 for 2.6 builders

### DIFF
--- a/2.6/builder/Dockerfile
+++ b/2.6/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/2.6/builder/Dockerfile.base
+++ b/2.6/builder/Dockerfile.base
@@ -1,1 +1,1 @@
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine

--- a/2.6/windows-builder/1809/Dockerfile
+++ b/2.6/windows-builder/1809/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-windowsservercore-1809
+FROM golang:1.20-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.6/windows-builder/1809/Dockerfile.base
+++ b/2.6/windows-builder/1809/Dockerfile.base
@@ -1,1 +1,1 @@
-FROM golang:1.19-windowsservercore-1809
+FROM golang:1.20-windowsservercore-1809

--- a/2.6/windows-builder/ltsc2022/Dockerfile
+++ b/2.6/windows-builder/ltsc2022/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-windowsservercore-ltsc2022
+FROM golang:1.20-windowsservercore-ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.6/windows-builder/ltsc2022/Dockerfile.base
+++ b/2.6/windows-builder/ltsc2022/Dockerfile.base
@@ -1,1 +1,1 @@
-FROM golang:1.19-windowsservercore-ltsc2022
+FROM golang:1.20-windowsservercore-ltsc2022


### PR DESCRIPTION
Recent versions of Caddy 2.6 require Go 1.20 to compile successfully. This patch upgrades the Go version for the builders.

Fixes https://github.com/dunglas/mercure/issues/770.