### PR TITLE
Update builder to Go 1.22.1

### DIFF
--- a/2.7/builder/Dockerfile
+++ b/2.7/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.18
+FROM golang:1.22.1-alpine3.19
 
 RUN apk add --no-cache \
 	ca-certificates \

--- a/2.7/builder/Dockerfile.base
+++ b/2.7/builder/Dockerfile.base
@@ -1,1 +1,1 @@
-FROM golang:1.21-alpine3.18
+FROM golang:1.22.1-alpine3.19


### PR DESCRIPTION
Update Go version from 1.21 to 1.22.1.

Enable building caddy with [xtemplate-caddy](https://github.com/infogulch/xtemplate-caddy) module, which require at least Go 1.22.1.