### PR TITLE
Support for arbitrary user

### DIFF
--- a/2.8/alpine/Dockerfile
+++ b/2.8/alpine/Dockerfile
@@ -36,6 +36,12 @@ RUN set -eux; \
 	rm -f /tmp/caddy.tar.gz; \
 	setcap cap_net_bind_service=+ep /usr/bin/caddy; \
 	chmod +x /usr/bin/caddy; \
+	chgrp -R 0 /config && chmod -R g=u /config; \
+	chgrp -R 0 /data && chmod -R g=u /data; \
+	chgrp -R 0 /config && chmod -R g=u /config; \
+	chgrp -R 0 /etc/caddy && chmod -R g=u /etc/caddy; \
+	chgrp -R 0 /usr/share/caddy && chmod -R g=u /usr/share/caddy; \
+	chgrp -R 0 /usr/bin/caddy && chmod -R g=u /usr/bin/caddy; \
 	caddy version
 
 # See https://caddyserver.com/docs/conventions#file-locations for details

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -36,6 +36,12 @@ RUN set -eux; \
 	rm -f /tmp/caddy.tar.gz; \
 	setcap cap_net_bind_service=+ep /usr/bin/caddy; \
 	chmod +x /usr/bin/caddy; \
+	chgrp -R 0 /config && chmod -R g=u /config; \
+	chgrp -R 0 /data && chmod -R g=u /data; \
+	chgrp -R 0 /config && chmod -R g=u /config; \
+	chgrp -R 0 /etc/caddy && chmod -R g=u /etc/caddy; \
+	chgrp -R 0 /usr/share/caddy && chmod -R g=u /usr/share/caddy; \
+	chgrp -R 0 /usr/bin/caddy && chmod -R g=u /usr/bin/caddy; \
 	caddy version
 
 # See https://caddyserver.com/docs/conventions#file-locations for details


### PR DESCRIPTION
By default, OpenShift Container Platform runs containers using an arbitrarily assigned user ID. This provides additional security against processes escaping the container due to a container engine vulnerability and thereby achieving escalated permissions on the host node.

For an image to support running as an arbitrary user, directories and files that may be written to by processes in the image should be owned by the root group and be read/writable by that group. Files to be executed should also have group execute permissions.

Because the container user is always a member of the root group, the container user can read and write these files. The root group does not have any special permissions (unlike the root user) so there are no security concerns with this arrangement.

(https://docs.redhat.com/en/documentation/openshift_container_platform/3.10/html/creating_images/creating-images-guidelines#openshift-specific-guidelines)

This pull request adds support for running Caddy as an arbitrary user:

```bash
chgrp -R 0 /config && chmod -R g=u /config;
chgrp -R 0 /data && chmod -R g=u /data;
chgrp -R 0 /etc/caddy && chmod -R g=u /etc/caddy;
chgrp -R 0 /usr/share/caddy && chmod -R g=u /usr/share/caddy;
chgrp -R 0 /usr/bin/caddy && chmod -R g=u /usr/bin/caddy;
```

