### PR TITLE
Drop Windows 1809, add ltsc2025

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,13 +15,6 @@ updates:
     timezone: Etc/UTC
   open-pull-requests-limit: 10
 - package-ecosystem: docker
-  directory: "/2.10/windows/1809"
-  schedule:
-    interval: daily
-    time: "02:00"
-    timezone: Etc/UTC
-  open-pull-requests-limit: 10
-- package-ecosystem: docker
   directory: "/2.10/windows/ltsc2022"
   schedule:
     interval: daily
@@ -29,7 +22,7 @@ updates:
     timezone: Etc/UTC
   open-pull-requests-limit: 10
 - package-ecosystem: docker
-  directory: "/2.10/windows-builder/1809"
+  directory: "/2.10/windows/ltsc2025"
   schedule:
     interval: daily
     time: "02:00"
@@ -37,6 +30,13 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/2.10/windows-builder/ltsc2022"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: Etc/UTC
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/2.10/windows-builder/ltsc2025"
   schedule:
     interval: daily
     time: "02:00"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,8 +34,9 @@ jobs:
         run: |
           bashbrew push --dry-run caddy
         if: github.repository != 'caddyserver/caddy-docker' || github.ref != 'refs/heads/master'
+
   docker-windows-build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # env:
     #   BASHBREW_LIBRARY: ./library
     #   BASHBREW_NAMESPACE: caddy
@@ -43,20 +44,20 @@ jobs:
       - uses: actions/checkout@master
       - name: non-master build test
         run: |
-          docker build -f 2.10/windows/1809/Dockerfile 2.10/windows
+          docker build -f 2.10/windows/ltsc2022/Dockerfile 2.10/windows/ltsc2022
         if: github.repository != 'caddyserver/caddy-docker' || github.ref != 'refs/heads/master'
       - name: install bashbrew
         run: curl -o /bashbrew.exe https://doi-janky.infosiftr.net/job/bashbrew/job/master/lastSuccessfulBuild/artifact/bashbrew-windows-amd64.exe
       - name: build
-        run: /bashbrew --arch windows-amd64 --constraint windowsservercore-1809 --namespace caddy --library ./library build caddy
+        run: /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library build caddy
       - name: push
         # NOTE: DOCKERHUB_TOKEN and DOCKERHUB_USERNAME must be present in https://github.com/caddyserver/caddy-docker/settings
         # the user must have permission to push to https://hub.docker.com/r/caddy/caddy
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin;
-          /bashbrew --arch windows-amd64 --constraint windowsservercore-1809 --namespace caddy --library ./library push caddy
+          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library push caddy
         if: github.repository == 'caddyserver/caddy-docker' && github.ref == 'refs/heads/master'
       - name: push (non-master dry run)
         run: |
-          /bashbrew --arch windows-amd64 --constraint windowsservercore-1809 --namespace caddy --library ./library push --dry-run caddy
+          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library push --dry-run caddy
         if: github.repository != 'caddyserver/caddy-docker' || github.ref != 'refs/heads/master'

--- a/2.10/windows-builder/1809/Dockerfile.base
+++ b/2.10/windows-builder/1809/Dockerfile.base
@@ -1,1 +1,0 @@
-FROM golang:1.23-windowsservercore-1809

--- a/2.10/windows-builder/ltsc2025/Dockerfile
+++ b/2.10/windows-builder/ltsc2025/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-windowsservercore-1809
+FROM golang:1.23-windowsservercore-ltsc2025
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.10/windows-builder/ltsc2025/Dockerfile.base
+++ b/2.10/windows-builder/ltsc2025/Dockerfile.base
@@ -1,0 +1,1 @@
+FROM golang:1.23-windowsservercore-ltsc2025

--- a/2.10/windows/1809/Dockerfile.base
+++ b/2.10/windows/1809/Dockerfile.base
@@ -1,1 +1,0 @@
-FROM mcr.microsoft.com/windows/servercore:1809

--- a/2.10/windows/ltsc2025/Dockerfile
+++ b/2.10/windows/ltsc2025/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.10/windows/ltsc2025/Dockerfile.base
+++ b/2.10/windows/ltsc2025/Dockerfile.base
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2025

--- a/stackbrew-config.yaml
+++ b/stackbrew-config.yaml
@@ -15,25 +15,25 @@ variants:
     tags: [ "builder-alpine" ]
     shared_tags: [ "builder" ]
     architectures: [ amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x ]
-  - dir: windows/1809
-    base_file: Dockerfile.windowsservercore-1809.base
-    tags: [ "windowsservercore-1809" ]
-    shared_tags: [ "windowsservercore", "latest" ]
-    architectures: [ windows-amd64 ]
-    constraints: [ windowsservercore-1809 ]
   - dir: windows/ltsc2022
     base_file: Dockerfile.windowsservercore-ltsc2022.base
     tags: [ "windowsservercore-ltsc2022" ]
     shared_tags: [ "windowsservercore", "latest" ]
     architectures: [ windows-amd64 ]
     constraints: [ windowsservercore-ltsc2022 ]
-  - dir: windows-builder/1809
-    tags: [ "builder-windowsservercore-1809" ]
-    shared_tags: [ "builder" ]
+  - dir: windows/ltsc2025
+    base_file: Dockerfile.windowsservercore-ltsc2025.base
+    tags: [ "windowsservercore-ltsc2025" ]
+    shared_tags: [ "windowsservercore", "latest" ]
     architectures: [ windows-amd64 ]
-    constraints: [ windowsservercore-1809 ]
+    constraints: [ windowsservercore-ltsc2025 ]
   - dir: windows-builder/ltsc2022
     tags: [ "builder-windowsservercore-ltsc2022" ]
     shared_tags: [ "builder" ]
     architectures: [ windows-amd64 ]
     constraints: [ windowsservercore-ltsc2022 ]
+  - dir: windows-builder/ltsc2025
+    tags: [ "builder-windowsservercore-ltsc2025" ]
+    shared_tags: [ "builder" ]
+    architectures: [ windows-amd64 ]
+    constraints: [ windowsservercore-ltsc2025 ]


### PR DESCRIPTION
As per https://github.com/docker-library/official-images/issues/18910 and https://github.com/docker-library/official-images/pull/19138