### PR TITLE
Add nanoserver build to workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,17 @@ updates:
     time: "02:00"
     timezone: Etc/UTC
   open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/2.10/windows-nanoserver/ltsc2022"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: Etc/UTC
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/2.10/windows-nanoserver/ltsc2025"
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: Etc/UTC
+  open-pull-requests-limit: 10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,19 +45,24 @@ jobs:
       - name: non-master build test
         run: |
           docker build -f 2.10/windows/ltsc2022/Dockerfile 2.10/windows/ltsc2022
+          docker build -f 2.10/windows-nanoserver/ltsc2022/Dockerfile 2.10/windows-nanoserver/ltsc2022
         if: github.repository != 'caddyserver/caddy-docker' || github.ref != 'refs/heads/master'
       - name: install bashbrew
         run: curl -o /bashbrew.exe https://doi-janky.infosiftr.net/job/bashbrew/job/master/lastSuccessfulBuild/artifact/bashbrew-windows-amd64.exe
       - name: build
-        run: /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library build caddy
+        run: |
+          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library build caddy;
+          /bashbrew --arch windows-amd64 --constraint windowsnanoserver-ltsc2022 --namespace caddy --library ./library build caddy
       - name: push
         # NOTE: DOCKERHUB_TOKEN and DOCKERHUB_USERNAME must be present in https://github.com/caddyserver/caddy-docker/settings
         # the user must have permission to push to https://hub.docker.com/r/caddy/caddy
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin;
-          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library push caddy
+          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library push caddy;
+          /bashbrew --arch windows-amd64 --constraint windowsnanoserver-ltsc2022 --namespace caddy --library ./library push caddy
         if: github.repository == 'caddyserver/caddy-docker' && github.ref == 'refs/heads/master'
       - name: push (non-master dry run)
         run: |
-          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library push --dry-run caddy
+          /bashbrew --arch windows-amd64 --constraint windowsservercore-ltsc2022 --namespace caddy --library ./library push --dry-run caddy;
+          /bashbrew --arch windows-amd64 --constraint windowsnanoserver-ltsc2022 --namespace caddy --library ./library push --dry-run caddy
         if: github.repository != 'caddyserver/caddy-docker' || github.ref != 'refs/heads/master'


### PR DESCRIPTION
### Changes

This PR adds Windows Nano Server container builds to the GitHub Actions workflow.

#### What's Changed

 **Added nanoserver builds to workflow**: Extended the GitHub Actions workflow to build and publish Nano Server container variants alongside the existing Server Core builds.

### Testing

- [ ] Confirmed workflow builds nanoserver images successfully

---

cc @francislavoie 